### PR TITLE
Don't set mips2/3 for mips r6

### DIFF
--- a/src/atomic_ops/sysdeps/gcc/mips.h
+++ b/src/atomic_ops/sysdeps/gcc/mips.h
@@ -41,11 +41,19 @@
 
 # if !defined(_ABI64) || _MIPS_SIM != _ABI64
 #   define AO_T_IS_INT
+# if defined(__mips_isa_rev) && (__mips_isa_rev >= 6)
+#   define AO_MIPS_SET_ISA    "       \n"
+# else
 #   define AO_MIPS_SET_ISA    "       .set mips2\n"
+# endif
 #   define AO_MIPS_LL_1(args) "       ll " args "\n"
 #   define AO_MIPS_SC(args)   "       sc " args "\n"
 # else
+# if defined(__mips_isa_rev) && (__mips_isa_rev >= 6)
+#   define AO_MIPS_SET_ISA    "       \n"
+# else
 #   define AO_MIPS_SET_ISA    "       .set mips3\n"
+# endif
 #   define AO_MIPS_LL_1(args) "       lld " args "\n"
 #   define AO_MIPS_SC(args)   "       scd " args "\n"
 # endif

--- a/src/atomic_ops/sysdeps/gcc/mips.h
+++ b/src/atomic_ops/sysdeps/gcc/mips.h
@@ -41,7 +41,7 @@
 
 # if !defined(_ABI64) || _MIPS_SIM != _ABI64
 #   define AO_T_IS_INT
-# if defined(__mips_isa_rev) && (__mips_isa_rev >= 6)
+# if __mips_isa_rev >= 6
 #   define AO_MIPS_SET_ISA    "       \n"
 # else
 #   define AO_MIPS_SET_ISA    "       .set mips2\n"
@@ -49,7 +49,7 @@
 #   define AO_MIPS_LL_1(args) "       ll " args "\n"
 #   define AO_MIPS_SC(args)   "       sc " args "\n"
 # else
-# if defined(__mips_isa_rev) && (__mips_isa_rev >= 6)
+# if __mips_isa_rev >= 6
 #   define AO_MIPS_SET_ISA    "       \n"
 # else
 #   define AO_MIPS_SET_ISA    "       .set mips3\n"


### PR DESCRIPTION
MIPS release 6 changes the encoding of some instructions, includes ll/sc.
If we set mips2/3 here, the generated binary will use the old encoding.